### PR TITLE
Add Render deployment setup with Flask app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # TableRunner
 Web app for detailed, automated TTRPG travel in an overworld.
+
+## Development
+
+Install dependencies and run the Flask app:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+## Deployment on Render
+
+This repository includes a `render.yaml` file for deploying to [Render](https://render.com). Create a new Web Service using this repo and Render will automatically install the dependencies and start the server with Gunicorn.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,11 @@
+import os
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return 'TableRunner is live!'
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,6 @@
+services:
+  - type: web
+    name: table-runner
+    env: python
+    buildCommand: "pip install -r requirements.txt"
+    startCommand: "gunicorn app:app"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask>=2.3
+gunicorn>=20.1


### PR DESCRIPTION
## Summary
- implement a minimal Flask application
- define dependencies
- add deployment configuration for Render
- document development and deployment instructions

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6867ca2df594832e99d5e747e7da4cb5